### PR TITLE
Use _enable_plugin() and _disable_plugin() instead of _enter_tree() and _exit_tree()

### DIFF
--- a/addons/logger/plugin.cfg
+++ b/addons/logger/plugin.cfg
@@ -16,6 +16,6 @@ New for the fork:
 - Adds a scripted breakpoint (optional in setting) so errors freeze the execution and shows relevant info in the godot debugger.
 - Adds support for multiple log files.
 - Adds a test scene that can be used as an example of how the plugin can be used."
-author="albinaask, avivajpeyi, Chrisknyfe, cstaaben, florianvazelle, SeannMoser"
-version="1.2.0"
+author="albinaask, avivajpeyi, Chrisknyfe, cstaaben, florianvazelle, SeannMoser, ahrbe1"
+version="1.2.1"
 script="plugin.gd"

--- a/addons/logger/plugin.gd
+++ b/addons/logger/plugin.gd
@@ -3,7 +3,7 @@ extends EditorPlugin
 
 
 
-func _enter_tree():
+func _enable_plugin():
 	
 	
 	#make sure log-stream is loaded to prevent godot error.
@@ -11,5 +11,5 @@ func _enter_tree():
 	add_autoload_singleton("Log", "res://addons/logger/logger.gd")
 
 
-func _exit_tree():
+func _disable_plugin():
 	remove_autoload_singleton("Log")


### PR DESCRIPTION
# Description

Uses `_enable_plugin()` and `_disable_plugin()` instead of `_enter_tree()` and `_exit_tree()`. This resolves two behaviors:

1. Resolves some autoload issues that occur when other plugins are loaded (See #12)
2. Resolves an issue where the editor always thinks the current scene is changed immediately upon load. This appears to be due to use of `add_autoload_singleton()` in `_enter_tree()`.

If relevant, describe linked issues:

Closes #12

Please also disclose whether there are any API changes that may effect users of the plugin.

No API changes.

<!-- For drafts, fill this in as you go; if you are done, make sure these are all done -->
#Checklist (replace space with X in the brackets to complete)

- [x] I have made corresponding changes to the documentation if applicable.
- [x] My code has passed the following test:
  - Reload the editor(Project->Reload current project), since godot plugins are fiddly and some errors only shows up after the plugin context has been reloaded.
  - run the res://tests/logtest.tscn scene.
  - This should produce several error messages, among one that halts the test execution and brings up the editor debugger.
  - press ![bild](https://github.com/albinaask/Log/assets/11806563/4e4b3d51-793f-496e-8193-c96b5884f1cc) once.
  - Now this message ![bild](https://github.com/albinaask/Log/assets/11806563/c3102b55-21b3-438e-a420-56971ad98d39) should show in the engine log.
- [x] I have correctly bumped the version in the config.cfg according to the following:
  - Has form x.y.z
  - x is bumped if API breaking changes is made, these are merged restrictively.
  - y is bumped if API is added upon or modified in a way that is backwards compatible.
  - z is bumped if bugs are fixed or only internal things are changed or rearranged that doesn't change the API at all.
  - Documentation changes or comments needs no version change.
  - Read more [here](https://semver.org/) if unclear.
     
<!-- Thanks to: https://github.com/Team-EnderIO/EnderIO/blob/dev/1.20.1/.github/pull_request_template.md?plain=1 for the building blocks of this template -->
