### PR TITLE
Adding default levels settings for newly created log streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ The fatal error level however (`Log.fatal("Message")`) also kills the program af
 In bigger projects you may want to have info about where messages are comming from and control the granularity independently by part of the project so you only show a few relevant debug messages among hundreds. This is solved by the concept of different streams. The idea is that you create one per project partition.
 
 ```
+
+# automatically uses the name of the script
+var my_logger = LogStream.new(self)
+
 var file_stream = LogStream.new("IO")
 var networking_stream = LogStream.new("Networking")
 
@@ -146,6 +150,24 @@ func do_something():
  	Log.current_log_level = Log.LogLevel.DEBUG
   	Log.debug("However this message will")
 ```
+
+You can even define default log level a specific log stream would use in `settings.gd`. This dict is used while contructing new loggers, and if a level is defined here, and none is passed in the constructor, this will be used
+```
+# settings.gd
+
+const DEFAULT_LEVELS = {
+    "my_script": LogStream.LogLevel.DEBUG
+}
+
+# my_script.gd
+
+var logger = LogStream.new(self)
+
+var _ready():
+	logger.debug("this will log")
+
+```
+
 
 ## Formatting log messages
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ In bigger projects you may want to have info about where messages are comming fr
 ```
 
 # automatically uses the name of the script
-var my_logger = LogStream.new(self)
+var my_logger = LogStream.create(self)
 
-var file_stream = LogStream.new("IO")
-var networking_stream = LogStream.new("Networking")
+var file_stream = LogStream.create("IO")
+var networking_stream = LogStream.create("Networking")
 
 func do_networking_stuff():
 	networking_stream.warn("No internet. Please connect to the internet for this feature to work")

--- a/addons/logger/log-stream.gd
+++ b/addons/logger/log-stream.gd
@@ -27,6 +27,7 @@ static var initialized = false
 ##Emits this signal whenever a message is recieved.
 signal log_message(level:LogLevel,message:String)
 
+static var LOGGERS = {}
 
 static func _static_init() -> void:
 	_ensure_setting_exists(settings.LOG_MESSAGE_FORMAT_KEY, settings.LOG_MESSAGE_FORMAT_DEFAULT_VALUE)
@@ -34,13 +35,19 @@ static func _static_init() -> void:
 	_ensure_setting_exists(settings.BREAK_ON_ERROR_KEY, settings.BREAK_ON_ERROR_DEFAULT_VALUE)
 	_ensure_setting_exists(settings.PRINT_TREE_ON_ERROR_KEY, settings.PRINT_TREE_ON_ERROR_DEFAULT_VALUE)
 
-func _init(log_name_or_obj, min_log_level:=LogLevel.DEFAULT, crash_behavior:Callable = default_crash_behavior):
-	if log_name_or_obj is Object:
-		_log_name = _get_script_name(log_name_or_obj)
-	else:
-		_log_name = log_name_or_obj
+func _init(log_name: String, min_log_level := LogLevel.DEFAULT, crash_behavior: Callable = default_crash_behavior):
+	_log_name = log_name
 	current_log_level = settings.DEFAULT_LEVELS.get(_log_name) if settings.DEFAULT_LEVELS.has(_log_name) else min_log_level
 	_crash_behavior = crash_behavior
+
+static func create(log_name_or_obj, min_log_level:=LogLevel.DEFAULT, crash_behavior:Callable = default_crash_behavior):
+	var log_name = ""
+	if log_name_or_obj is Object:
+		log_name = log_name_or_obj.get_script().get_path().split("/")[-1].split(".")[0]
+	else:
+		log_name = log_name_or_obj
+
+	return LogStream.LOGGERS[log_name] if LogStream.LOGGERS.has(log_name) else LogStream.new(log_name, min_log_level, crash_behavior)
 
 ##prints a message to the log at the debug level.
 func debug(message:String,values:Variant=null):
@@ -204,18 +211,6 @@ func _get_reduced_stack(stack:Array)->String:
 		##TODO: test print_debug()
 		stack_trace_message = "No stack trace available, please run from within the editor or connect to a remote debug context."
 	return stack_trace_message
-
-
-func _get_script_name(obj: Object):
-	var base_properties = obj.get_script().get_base_script().get_script_property_list()
-	var my_properties = obj.get_script().get_script_property_list()
-	for prop in my_properties:
-		if not prop in base_properties and prop["name"].contains(".gd"):
-			return prop["name"].split(".")[0]
-
-	print("ERROR: savable script name not found")
-	return ""
-
 
 ##Internal method.
 func _set_level(level:LogLevel):

--- a/addons/logger/plugin.cfg
+++ b/addons/logger/plugin.cfg
@@ -17,5 +17,5 @@ New for the fork:
 - Adds support for multiple log files.
 - Adds a test scene that can be used as an example of how the plugin can be used."
 author="albinaask, avivajpeyi, Chrisknyfe, cstaaben, florianvazelle, SeannMoser, ahrbe1"
-version="1.2.1"
+version="1.2.2"
 script="plugin.gd"

--- a/addons/logger/settings.gd
+++ b/addons/logger/settings.gd
@@ -18,3 +18,7 @@ const BREAK_ON_ERROR_DEFAULT_VALUE = true
 ##Whether to dump the tree to the log on error.
 const PRINT_TREE_ON_ERROR_KEY = "addons/Log/print_tree_on_error"
 const PRINT_TREE_ON_ERROR_DEFAULT_VALUE = false
+
+const DEFAULT_LEVELS = {
+	# "script_name": LevelStream.LogLevel.DEBUG
+}

--- a/tests/logtest.tscn
+++ b/tests/logtest.tscn
@@ -31,7 +31,7 @@ func _ready():
 	
 	#Create a new logstream that is independently controlled from main, muting every message below WARN. 
 	#(LogStream.LogLevel is equal to Log.LogLevel since Log is a LogStream).
-	var logger = LogStream.new(\"test logger\", LogStream.LogLevel.WARN, func():
+	var logger = LogStream.create(\"test logger\", LogStream.LogLevel.WARN, func():
 		#Reset old value so user don't get confused.
 		ProjectSettings.set_setting(Log.settings.BREAK_ON_ERROR_KEY, _break_on_error_current_val)
 		


### PR DESCRIPTION
# Description

this PR does 2 things

1. allows create log streams using this syntax

```
var logger = LogStream.new(self)
```

so that we dont have to manually name it, and this line can be copied into other scripts and used easily

2. have an externally defined log levels, so that, it can be changed on the fly as required, without actually modifying the script where the logger is

```
# settings.gd

const DEFAULT_LEVELS = {
	"my_script": LogStream.LogLevel.DEBUG
}

# my_script.gd

var logger = LogStream.new(self)

var _ready():
	logger.debug("this will log")

```


If relevant, describe linked issues:
Closes #(issue) none

Please also disclose whether there are any API changes that may effect users of the plugin.

<!-- For drafts, fill this in as you go; if you are done, make sure these are all done -->
#Checklist (replace space with X in the brackets to complete)

- [x] I have made corresponding changes to the documentation if applicable.
- [x] My code has passed the following test:
  - Reload the editor(Project->Reload current project), since godot plugins are fiddly and some errors only shows up after the plugin context has been reloaded.
  - run the res://tests/logtest.tscn scene.
  - This should produce several error messages, among one that halts the test execution and brings up the editor debugger.
  - press ![bild](https://github.com/albinaask/Log/assets/11806563/4e4b3d51-793f-496e-8193-c96b5884f1cc) once.
  - Now this message ![bild](https://github.com/albinaask/Log/assets/11806563/c3102b55-21b3-438e-a420-56971ad98d39) should show in the engine log.
- [x] I have correctly bumped the version in the config.cfg according to the following:
  - Has form x.y.z
  - x is bumped if API breaking changes is made, these are merged restrictively.
  - y is bumped if API is added upon or modified in a way that is backwards compatible.
  - z is bumped if bugs are fixed or only internal things are changed or rearranged that doesn't change the API at all.
  - Documentation changes or comments needs no version change.
  - Read more [here](https://semver.org/) if unclear.
     
<!-- Thanks to: https://github.com/Team-EnderIO/EnderIO/blob/dev/1.20.1/.github/pull_request_template.md?plain=1 for the building blocks of this template -->
