### PR TITLE
show script name, function name and line number in logs

### DIFF
--- a/addons/logger/log-stream.gd
+++ b/addons/logger/log-stream.gd
@@ -156,10 +156,15 @@ func _get_format_data(msg:String, lvl:LogLevel)->Dictionary:
 	now["day"] = "%02d"%now["day"]
 	now["month"] = "%02d"%now["month"]
 	
+	var call = get_stack()[3]
+	var script = call["source"].split("/")[-1]
 	var format_data := {
 			"log_name":_log_name,
 			"message":msg,
-			"level":LogLevel.keys()[lvl]
+			"level":LogLevel.keys()[lvl],
+			"script": script,
+			"function": call["function"],
+            "line": call["line"]
 		}
 	format_data.merge(now)
 	return format_data

--- a/addons/logger/plugin.cfg
+++ b/addons/logger/plugin.cfg
@@ -17,5 +17,5 @@ New for the fork:
 - Adds support for multiple log files.
 - Adds a test scene that can be used as an example of how the plugin can be used."
 author="albinaask, avivajpeyi, Chrisknyfe, cstaaben, florianvazelle, SeannMoser, ahrbe1"
-version="1.2.1"
+version="1.2.2"
 script="plugin.gd"

--- a/addons/logger/settings.gd
+++ b/addons/logger/settings.gd
@@ -3,7 +3,7 @@
 ## Controls how the message should be formatted, follows String.format(), valid keys are: "level", "time", "log_name", "message"
 const LOG_MESSAGE_FORMAT_KEY = "addons/Log/log_message_format"
 ##BBCode friendly, aka any BBCode may be inserted here.
-const LOG_MESSAGE_FORMAT_DEFAULT_VALUE = "{log_name}/{level} [lb]{hour}:{minute}:{second}[rb] {message}"
+const LOG_MESSAGE_FORMAT_DEFAULT_VALUE = "{log_name}/{level} [lb]{hour}:{minute}:{second}[rb] {script}:{function}:{line} {message}"
 
 ## Whether to use the UTC time or the user
 const USE_UTC_TIME_FORMAT_KEY = "addons/Log/use_utc_time_format"


### PR DESCRIPTION
# Description

Showing source of logs really helps to judge where exactly the logs are coming from

If relevant, describe linked issues:
Closes #(issue)

Please also disclose whether there are any API changes that may effect users of the plugin.

<!-- For drafts, fill this in as you go; if you are done, make sure these are all done -->
#Checklist (replace space with X in the brackets to complete)

- [x] I have made corresponding changes to the documentation if applicable.
- [x] My code has passed the following test:
  - Reload the editor(Project->Reload current project), since godot plugins are fiddly and some errors only shows up after the plugin context has been reloaded.
  - run the res://tests/logtest.tscn scene.
  - This should produce several error messages, among one that halts the test execution and brings up the editor debugger.
  - press ![bild](https://github.com/albinaask/Log/assets/11806563/4e4b3d51-793f-496e-8193-c96b5884f1cc) once.
  - Now this message ![bild](https://github.com/albinaask/Log/assets/11806563/c3102b55-21b3-438e-a420-56971ad98d39) should show in the engine log.
- [x] I have correctly bumped the version in the config.cfg according to the following:
  - Has form x.y.z
  - x is bumped if API breaking changes is made, these are merged restrictively.
  - y is bumped if API is added upon or modified in a way that is backwards compatible.
  - z is bumped if bugs are fixed or only internal things are changed or rearranged that doesn't change the API at all.
  - Documentation changes or comments needs no version change.
  - Read more [here](https://semver.org/) if unclear.
     
<!-- Thanks to: https://github.com/Team-EnderIO/EnderIO/blob/dev/1.20.1/.github/pull_request_template.md?plain=1 for the building blocks of this template -->
